### PR TITLE
Update openapi_spec.yaml

### DIFF
--- a/scripts/openapi_spec.yaml
+++ b/scripts/openapi_spec.yaml
@@ -21,4 +21,4 @@ paths: {}
 host: "${endpoint_service}"
 x-google-endpoints:
   - name: "${endpoint_service}"
-    target: ${target}"
+    target: "${target}"


### PR DESCRIPTION
This change resolved this error I hit:

```
+ terraform apply -input=false terraform.tfplan
module.cloud-ep-dns.google_endpoints_service.default: Creating...

Error: googleapi: Error 400: Cannot convert to service config.
'location: "toplevel"
kind: ERROR
message: "endpoint: Endpoint \'frontend.endpoints.REDACTED.cloud.goog\'\'s target \'34.xx.xx.xx\"\' in service \'frontend.endpoints.REDACTED.cloud.goog\' is neither a fully qualified domain name nor a valid IPv4 address."
', badRequest

  on .terraform/modules/cloud-ep-dns/main.tf line 68, in resource "google_endpoints_service" "default":
  68: resource "google_endpoints_service" "default" {

```
Note: `34.xx.xx.xx` is a redacted public IP address.

